### PR TITLE
[Launcher] Replace deprecated functions

### DIFF
--- a/launcher.js
+++ b/launcher.js
@@ -48,7 +48,7 @@ class Launcher {
 		const alreadyRunning = this.games.length > 0;
 
 		if(!alreadyRunning && fs.existsSync(nativesFolder)) {
-			fs.rmdirSync(nativesFolder, { recursive: true });
+			fs.rmSync(nativesFolder, { recursive: true });
 		}
 
 		console.log("Downloading libraries...");

--- a/patcher.js
+++ b/patcher.js
@@ -10,7 +10,7 @@ class Patcher {
 		let tempFolder = versionFolder + "/patch/";
 		
 		if(fs.existsSync(tempFolder)) {
-			fs.rmdirSync(tempFolder, { recursive: true });
+			fs.rmSync(tempFolder, { recursive: true });
 		}
 		
 		fs.mkdirSync(tempFolder);
@@ -109,7 +109,7 @@ class Patcher {
 		});
 
 		fs.renameSync(mapped,  outputFile);
-		fs.rmdirSync(tempFolder, { recursive: true });
+		fs.rmSync(tempFolder, { recursive: true });
 	}
 
 }


### PR DESCRIPTION
Replaced `fs.rmdirSync()` (deprecated) with `fs.rmSync()`.

:)